### PR TITLE
Feature/use dmsg connection as singleton

### DIFF
--- a/transport.go
+++ b/transport.go
@@ -18,7 +18,7 @@ import (
 
 // Defaults for dmsg configuration, such as discovery URL
 const (
-	DefaultDiscoveryURL = "https://messaging.discovery.skywire.skycoin.net"
+	DefaultDiscoveryURL = "https://messaging.discovery.skywire.skycoin.com"
 )
 
 // DMSGTransport holds information about client who is initiating communication.


### PR DESCRIPTION
Singleton keeps connection per transport instance, that holds pub/sec key-pair.
Updated official discovery URL that's used as default for establishing connections.

Resolves #9 