### PR TITLE
Add retry counter for establishing dmsg transport

### DIFF
--- a/dmsg-http.go
+++ b/dmsg-http.go
@@ -4,8 +4,10 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/skycoin/dmsg"
 	"github.com/skycoin/dmsg/cipher"
 	"github.com/skycoin/dmsg/disc"
+	"github.com/skycoin/skycoin/src/util/logging"
 )
 
 // DefaultDMSGClient creates http Client using default discovery service
@@ -18,10 +20,12 @@ func DefaultDMSGClient(pubKey cipher.PubKey, secKey cipher.SecKey) *http.Client 
 // Returned client is using dmsg transport protocol instead of tcp for establishing connection
 func DMSGClient(discovery disc.APIClient, pubKey cipher.PubKey, secKey cipher.SecKey) *http.Client {
 	transport := DMSGTransport{
-		Discovery: discovery,
-		PubKey:    pubKey,
-		SecKey:    secKey,
+		Discovery:  discovery,
+		PubKey:     pubKey,
+		SecKey:     secKey,
+		RetryCount: 10,
 	}
+	transport.dmsgC = dmsg.NewClient(pubKey, secKey, discovery, dmsg.SetLogger(logging.MustGetLogger("dmsgC_httpC")))
 
 	return &http.Client{
 		Transport: transport,

--- a/dmsg-http_test.go
+++ b/dmsg-http_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"golang.org/x/net/nettest"
 
-	dmsghttp "github.com/skycoin/dmsg-http"
+	dmsghttp "github.com/SkycoinProject/dmsg-http"
 )
 
 const (


### PR DESCRIPTION
Counter is used for establishing transport.
Modified a way dmsg client is instantiated.
Updated dependency in the test